### PR TITLE
Add bool support to framework

### DIFF
--- a/debug-tools/examples/arc.rs
+++ b/debug-tools/examples/arc.rs
@@ -12,6 +12,7 @@ struct ArcDebug {
     angle_start: i32,
     angle_sweep: i32,
     stroke_width: u32,
+    show_bounding_box: bool,
 }
 
 impl App for ArcDebug {
@@ -25,6 +26,7 @@ impl App for ArcDebug {
             angle_start: 0,
             angle_sweep: 30,
             stroke_width: 1,
+            show_bounding_box: false,
         }
     }
 
@@ -35,6 +37,7 @@ impl App for ArcDebug {
             Parameter::new("start", &mut self.angle_start),
             Parameter::new("sweep", &mut self.angle_sweep),
             Parameter::new("stroke", &mut self.stroke_width),
+            Parameter::new("show BB", &mut self.show_bounding_box),
         ]
     }
 
@@ -52,9 +55,15 @@ impl App for ArcDebug {
         let style = PrimitiveStyle::with_stroke(Rgb888::CSS_SPRING_GREEN, self.stroke_width);
         let styled_arc = arc.into_styled(style);
 
-        draw::bounding_box(&styled_arc, display);
+        if self.show_bounding_box {
+            draw::bounding_box(&styled_arc, display);
+        }
+
         styled_arc.draw(display)?;
-        draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+
+        if self.show_bounding_box {
+            draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+        }
 
         Ok(())
     }

--- a/debug-tools/examples/circle.rs
+++ b/debug-tools/examples/circle.rs
@@ -10,6 +10,7 @@ struct CircleDebug {
     center: Point,
     diameter: u32,
     stroke_width: u32,
+    show_bounding_box: bool,
 }
 
 impl App for CircleDebug {
@@ -21,6 +22,7 @@ impl App for CircleDebug {
             center: Point::new(128, 128),
             diameter: 50,
             stroke_width: 1,
+            show_bounding_box: false,
         }
     }
 
@@ -29,6 +31,7 @@ impl App for CircleDebug {
             Parameter::new("center", &mut self.center),
             Parameter::new("diameter", &mut self.diameter),
             Parameter::new("stroke", &mut self.stroke_width),
+            Parameter::new("show BB", &mut self.show_bounding_box),
         ]
     }
 
@@ -45,9 +48,15 @@ impl App for CircleDebug {
             .build();
         let styled_circle = circle.into_styled(style);
 
-        draw::bounding_box(&styled_circle, display);
+        if self.show_bounding_box {
+            draw::bounding_box(&styled_circle, display);
+        }
+
         styled_circle.draw(display)?;
-        draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+
+        if self.show_bounding_box {
+            draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+        }
 
         Ok(())
     }

--- a/debug-tools/examples/sector.rs
+++ b/debug-tools/examples/sector.rs
@@ -12,6 +12,7 @@ struct SectorDebug {
     angle_start: i32,
     angle_sweep: i32,
     stroke_width: u32,
+    show_bounding_box: bool,
 }
 
 impl App for SectorDebug {
@@ -25,6 +26,7 @@ impl App for SectorDebug {
             angle_start: 0,
             angle_sweep: 30,
             stroke_width: 1,
+            show_bounding_box: false,
         }
     }
 
@@ -35,6 +37,7 @@ impl App for SectorDebug {
             Parameter::new("start", &mut self.angle_start),
             Parameter::new("sweep", &mut self.angle_sweep),
             Parameter::new("stroke", &mut self.stroke_width),
+            Parameter::new("show BB", &mut self.show_bounding_box),
         ]
     }
 
@@ -56,9 +59,15 @@ impl App for SectorDebug {
             .build();
         let styled_sector = sector.into_styled(style);
 
-        draw::bounding_box(&styled_sector, display);
+        if self.show_bounding_box {
+            draw::bounding_box(&styled_sector, display);
+        }
+
         styled_sector.draw(display)?;
-        draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+
+        if self.show_bounding_box {
+            draw::point(self.center, Rgb888::CSS_LIGHT_SKY_BLUE, display);
+        }
 
         Ok(())
     }

--- a/framework/src/parameter.rs
+++ b/framework/src/parameter.rs
@@ -26,6 +26,7 @@ pub enum Value<'a> {
     U32(&'a mut u32),
     I32(&'a mut i32),
     Point(&'a mut Point),
+    Bool(&'a mut bool),
 }
 
 impl<'a> Value<'a> {
@@ -49,6 +50,10 @@ impl<'a> Value<'a> {
                 Event::MouseMove(p) => **point = p,
                 _ => {}
             },
+            Self::Bool(value) => match event {
+                Event::Down | Event::Left | Event::Up | Event::Right => **value ^= true,
+                _ => {}
+            },
         }
     }
 }
@@ -59,6 +64,7 @@ impl fmt::Display for Value<'_> {
             Value::U32(value) => value.fmt(f),
             Value::I32(value) => value.fmt(f),
             Value::Point(Point { x, y }) => write!(f, "({}, {})", x, y),
+            Value::Bool(value) => value.fmt(f),
         }
     }
 }
@@ -78,5 +84,11 @@ impl<'a> From<&'a mut u32> for Value<'a> {
 impl<'a> From<&'a mut Point> for Value<'a> {
     fn from(value: &'a mut Point) -> Self {
         Self::Point(value)
+    }
+}
+
+impl<'a> From<&'a mut bool> for Value<'a> {
+    fn from(value: &'a mut bool) -> Self {
+        Self::Bool(value)
     }
 }


### PR DESCRIPTION
This PR adds support for `bool` fields to the debug tools framework. 

The display could get cluttered for small primitives if the BB was always drawn. The debug tools now have an additional setting to toggle the visibility of the BB.