### PR TITLE
Move more examples here

### DIFF
--- a/debug-tools/examples/ellipse.rs
+++ b/debug-tools/examples/ellipse.rs
@@ -1,0 +1,129 @@
+//! # Example: `Ellipse` primitive.
+//!
+//! Click and drag to move the bottom right corner of the ellipse's bounding box around the screen.
+//!
+//! The stroke size can be increased or decreased using the up and down arrow keys.
+//!
+//! This example is not particularly useful on it's own, but is helpful when debugging ellipse
+//! rendering.
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_6X9, MonoTextStyle},
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::*,
+    text::Text,
+};
+use embedded_graphics_simulator::{
+    sdl2::Keycode, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+};
+
+fn draw_ellipse(
+    top_left: Point,
+    size: Size,
+    stroke_width: u32,
+    display: &mut SimulatorDisplay<Rgb888>,
+) {
+    display.clear(Rgb888::BLACK).unwrap();
+
+    Text::new(
+        &format!("S: {}\n{:?}", stroke_width, size),
+        Point::new(5, 10),
+        MonoTextStyle::new(&FONT_6X9, Rgb888::MAGENTA),
+    )
+    .draw(display)
+    .unwrap();
+
+    // Bounding rect
+    Rectangle::new(top_left, size)
+        .into_styled(PrimitiveStyle::with_stroke(Rgb888::WHITE, 1))
+        .draw(display)
+        .unwrap();
+
+    Ellipse::new(top_left, size)
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_width(stroke_width)
+                .stroke_color(Rgb888::RED)
+                .fill_color(Rgb888::GREEN)
+                .build(),
+        )
+        .draw(display)
+        .unwrap();
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(200, 200));
+    let output_settings = OutputSettingsBuilder::new()
+        .scale(2)
+        .pixel_spacing(1)
+        .build();
+    let mut window = Window::new("Ellipse debugger", &output_settings);
+
+    let top_left = Point::new(50, 50);
+
+    let mut mouse_down = false;
+
+    let mut bounding_rect = Rectangle::with_corners(top_left, Point::new(100, 100));
+
+    let mut stroke_width = 5;
+
+    draw_ellipse(
+        bounding_rect.top_left,
+        bounding_rect.size,
+        stroke_width,
+        &mut display,
+    );
+
+    'running: loop {
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::MouseButtonDown { point, .. } => {
+                    mouse_down = true;
+
+                    bounding_rect = Rectangle::with_corners(top_left, point);
+
+                    draw_ellipse(
+                        bounding_rect.top_left,
+                        bounding_rect.size,
+                        stroke_width,
+                        &mut display,
+                    );
+                }
+                SimulatorEvent::KeyDown { keycode, .. } => {
+                    match keycode {
+                        Keycode::Up => stroke_width += 1,
+                        Keycode::Down => stroke_width = (stroke_width as i32 - 1).max(0) as u32,
+                        _ => (),
+                    }
+
+                    draw_ellipse(
+                        bounding_rect.top_left,
+                        bounding_rect.size,
+                        stroke_width,
+                        &mut display,
+                    );
+                }
+                SimulatorEvent::MouseButtonUp { .. } => mouse_down = false,
+                SimulatorEvent::MouseMove { point, .. } => {
+                    if mouse_down {
+                        bounding_rect = Rectangle::with_corners(top_left, point);
+
+                        draw_ellipse(
+                            bounding_rect.top_left,
+                            bounding_rect.size,
+                            stroke_width,
+                            &mut display,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/debug-tools/examples/rounded-rectangle.rs
+++ b/debug-tools/examples/rounded-rectangle.rs
@@ -1,0 +1,109 @@
+//! # Example: Rounded rectangle
+//!
+//! This example draws a `RoundedRectangle`. Click and drag to move a corner of the rounded
+//! rectangle around the screen. The up/down arrow keys adjust stroke width, left/right the corner
+//! radius. Space cycles the stroke alignment between center/outside/inside.
+
+use embedded_graphics::{pixelcolor::Rgb888, prelude::*, primitives::*};
+use embedded_graphics_simulator::{
+    sdl2::Keycode, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+};
+
+fn draw(
+    base_rectangle: Rectangle,
+    radius: Size,
+    stroke_width: u32,
+    align: StrokeAlignment,
+    display: &mut SimulatorDisplay<Rgb888>,
+) {
+    display.clear(Rgb888::BLACK).unwrap();
+
+    RoundedRectangle::with_equal_corners(base_rectangle, radius)
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_width(stroke_width)
+                .stroke_color(Rgb888::RED)
+                .stroke_alignment(align)
+                .fill_color(Rgb888::GREEN)
+                .build(),
+        )
+        .draw(display)
+        .unwrap();
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(200, 200));
+    let output_settings = OutputSettingsBuilder::new()
+        .scale(2)
+        .pixel_spacing(1)
+        .build();
+    let mut window = Window::new("Rounded rectangle debugger", &output_settings);
+
+    let top_left = Point::new(20, 20);
+
+    let mut mouse_down = false;
+
+    let mut base_rectangle = Rectangle::with_corners(top_left, Point::new(100, 100));
+
+    let mut stroke_width = 5;
+
+    let mut radius = 20;
+
+    let mut align = StrokeAlignment::Center;
+
+    draw(
+        base_rectangle,
+        Size::new(radius, radius),
+        stroke_width,
+        align,
+        &mut display,
+    );
+
+    'running: loop {
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::MouseButtonDown { point, .. } => {
+                    mouse_down = true;
+
+                    base_rectangle = Rectangle::with_corners(top_left, point);
+                }
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Up => stroke_width += 1,
+                    Keycode::Down => stroke_width = stroke_width.saturating_sub(1),
+
+                    Keycode::Right => radius += 1,
+                    Keycode::Left => radius = radius.saturating_sub(1),
+
+                    Keycode::Space => {
+                        align = match align {
+                            StrokeAlignment::Center => StrokeAlignment::Outside,
+                            StrokeAlignment::Outside => StrokeAlignment::Inside,
+                            StrokeAlignment::Inside => StrokeAlignment::Center,
+                        }
+                    }
+                    _ => (),
+                },
+                SimulatorEvent::MouseButtonUp { .. } => mouse_down = false,
+                SimulatorEvent::MouseMove { point, .. } => {
+                    if mouse_down {
+                        base_rectangle = Rectangle::with_corners(top_left, point);
+                    }
+                }
+                _ => {}
+            }
+
+            draw(
+                base_rectangle,
+                Size::new(radius, radius),
+                stroke_width,
+                align,
+                &mut display,
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Move a couple more "example" debug tools from embedded-graphics/examples to here.

These don't use the nice framework, but that can be changed later if we need to come back and debug these shapes.