### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ members = [
     "debug-tools",
 ]
 
+[workspace.dependencies]
+embedded-graphics = "0.7.1"
+embedded-graphics-simulator = "0.4.0"
+
 [patch.crates-io]
 embedded-graphics = { git = "https://github.com/embedded-graphics/embedded-graphics.git"}
 embedded-graphics-simulator = { git = "https://github.com/embedded-graphics/simulator.git"}
+# embedded-graphics = { path = "../embedded-graphics"}
+# embedded-graphics-core = { path = "../embedded-graphics/core"}

--- a/debug-tools/Cargo.toml
+++ b/debug-tools/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "line"
+name = "debug-toolsexamples"
 version = "0.1.0"
 authors = ["Ralf Fuest <mail@rfuest.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]
 framework = { path = "../framework" }
-embedded-graphics = "0.7.0-beta.2"
-embedded-graphics-simulator = "0.3.0-alpha.2"
+embedded-graphics.workspace = true
+embedded-graphics-simulator.workspace = true

--- a/debug-tools/examples/line-intersection.rs
+++ b/debug-tools/examples/line-intersection.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::{
     geometry::AnchorPoint,
-    mono_font::{latin1::FONT_6X10, MonoTextStyle},
+    mono_font::{iso_8859_1::FONT_6X10, MonoTextStyle},
     pixelcolor::{Rgb565, WebColors},
     prelude::*,
     primitives::Line,

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -2,10 +2,9 @@
 name = "framework"
 version = "0.1.0"
 authors = ["Ralf Fuest <mail@rfuest.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]
-embedded-graphics = "0.7.0-beta.1"
-embedded-graphics-simulator = "0.3.0-alpha.2"
-sdl2 = "0.32.2"
+embedded-graphics.workspace = true
+embedded-graphics-simulator.workspace = true

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
 const MIN_FRAME_DURATION: Duration = Duration::from_millis(1000 / 60);
 
 pub trait App {
-    type Color: PixelColor + From<BinaryColor> + Into<Rgb888>;
+    type Color: PixelColor + From<BinaryColor> + Into<Rgb888> + From<Rgb888>;
     const DISPLAY_SIZE: Size;
 
     fn new() -> Self;

--- a/framework/src/menu.rs
+++ b/framework/src/menu.rs
@@ -5,8 +5,10 @@ use embedded_graphics::{
     primitives::{Line, PrimitiveStyle, Rectangle},
     text::Text,
 };
-use embedded_graphics_simulator::{SimulatorEvent, Window};
-use sdl2::{keyboard::Keycode, mouse::MouseButton};
+use embedded_graphics_simulator::{
+    sdl2::{Keycode, MouseButton},
+    SimulatorEvent, Window,
+};
 
 use crate::{parameter::Value, Parameter};
 


### PR DESCRIPTION
This PR updates the dependencies and fixes some incompatibilities with newer e-g and simulator versions. I've used the new workspace dependencies feature, so that this repo will now require Rust 1.64, but IMO this doesn't matter for the debug tools.